### PR TITLE
Feat/moka-53

### DIFF
--- a/src/atoms.js
+++ b/src/atoms.js
@@ -40,3 +40,13 @@ export const detailMCQuestionState = atom({
   key: "detailMCQuestionState",
   default: [],
 });
+
+export const surveyImage = atom({
+  key: "surveyImage",
+  default: "",
+});
+
+export const surveyCategory = atom({
+  key: "surveyCategory",
+  default: [],
+});

--- a/src/components/surveys/create/NavBar.jsx
+++ b/src/components/surveys/create/NavBar.jsx
@@ -13,6 +13,8 @@ import {
   detailMCQuestionState,
   surveyEndDate,
   surveyStartDate,
+  surveyCategory,
+  surveyImage,
 } from "../../../atoms";
 import { CustomSwitch } from "./CustomizedSwitches";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
@@ -38,7 +40,8 @@ const style = {
 function NavBar() {
   const surveyList = useRecoilValue(surveyListState);
   const detailList = useRecoilValue(detailMCQuestionState);
-
+  const category = useRecoilValue(surveyCategory);
+  const surveyImg = useRecoilValue(surveyImage);
   const title = useRecoilValue(surveyTitle);
   const summary = useRecoilValue(surveySummary);
   const [isAnonymous, setIsAnonymous] = useRecoilState(surveyIsAnonymous);
@@ -78,7 +81,13 @@ function NavBar() {
         startDate +
         "\n" +
         "종료 날짜: " +
-        endDate
+        endDate +
+        "\n" +
+        "카테고리 : " +
+        category +
+        "\n" +
+        "이미지 : " +
+        surveyImg
     );
 
     const surveyInfo = {
@@ -89,6 +98,8 @@ function NavBar() {
       endDate: endDate,
       questions: surveyList,
       multiQuestions: detailList,
+      category: category,
+      surveyImage: surveyImg,
     };
 
     console.log(JSON.stringify(surveyInfo));

--- a/src/components/surveys/create/SelectCategory.jsx
+++ b/src/components/surveys/create/SelectCategory.jsx
@@ -7,6 +7,8 @@ import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
 import Chip from "@mui/material/Chip";
+import { useRecoilState } from "recoil";
+import { surveyCategory } from "../../../atoms";
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
@@ -41,6 +43,8 @@ function getStyles(item, category, theme) {
 export default function SelectCategory() {
   const theme = useTheme();
   const [category, setcategory] = React.useState([]);
+  const [surveyCategoryInput, setSurveyCategory] =
+    useRecoilState(surveyCategory);
 
   const handleChange = (event) => {
     const {
@@ -50,6 +54,7 @@ export default function SelectCategory() {
       // On autofill we get a stringified value.
       typeof value === "string" ? value.split(",") : value
     );
+    setSurveyCategory(category);
   };
 
   return (

--- a/src/components/surveys/create/SurveyImg.jsx
+++ b/src/components/surveys/create/SurveyImg.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCamera } from "@fortawesome/free-solid-svg-icons";
+import { useRecoilState } from "recoil";
+import { surveyImage } from "../../../atoms";
 
 const Container = styled.div`
   display: flex;
@@ -38,6 +40,7 @@ const UploadBtn = styled.label`
 `;
 export default function SurveyImg() {
   const [selectedImage, setSelectedImage] = useState(null);
+  const [surveyImageInput, setSurveyImage] = useRecoilState(surveyImage);
 
   return (
     <Container>
@@ -46,6 +49,7 @@ export default function SurveyImg() {
         id="surveyImg"
         onChange={(event) => {
           setSelectedImage(event.target.files[0]);
+          setSurveyImage(event.target.files[0]);
         }}
         style={{ display: "none" }}
       />


### PR DESCRIPTION
## 설문 이미지 및 카테고리 저장 구현<!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-53

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 설문 생성 시 카테고리 지정 가능
- 설문 생성 시 이미지 저장 가능

### 리뷰 포인트
<!-- 오류 있는지 함께 확인해주세요 -->
- 일단 File Object를 그대로 서버로 넘겨주는 방식을 사용했는데, 설문 조회 시에 사진을 받아올 수 있을 지 확인해봐야 할 것 같습니다.
- 설문 생성 버튼을 누른 후 alert와 console을 통해 이미지와 카테고리를 잘 받아오는 지 확인해주세요

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
![image](https://user-images.githubusercontent.com/63714074/196018858-8c47af7a-c795-41d7-bfef-73caa9ff0b4a.png)

- [ ] 서버에서 category와 surverImage를 받는 코드를 작성해야 할 것 같습니다.