### PR TITLE
feat: 이메일/ 닉네임 중복 검사 기능 추가

### DIFF
--- a/src/components/users/SignUp/SignEssentialForm.jsx
+++ b/src/components/users/SignUp/SignEssentialForm.jsx
@@ -12,6 +12,7 @@ import {
   isPasswordConfirmState,
 } from "./SignUpState";
 import { Box } from "@mui/material";
+import axios from "axios";
 
 export default function SignEssentialForm({}) {
   // 이메일, 닉네임, 비밀번호, 비밀번호 확인
@@ -45,8 +46,34 @@ export default function SignEssentialForm({}) {
       setEmailMessage("이메일 형식으로 입력해주세요.");
       setIsEmail(false);
     } else {
-      setEmailMessage("올바른 이메일 형식입니다.");
-      setIsEmail(true);
+      axios
+        .get("/api/v1/users/check-email-duplication", {
+          params: {
+            email: emailCurrent,
+          },
+        })
+        .then(function (response) {
+          if (response.data.message.includes("성공")) {
+            if (response.data.data.isDuplicated === false) {
+              setEmailMessage("사용 가능한 이메일입니다.");
+              setIsEmail(true);
+            } else {
+              setEmailMessage(
+                "중복 이메일이 있습니다. 다른 이메일을 입력해주세요."
+              );
+              setIsEmail(false);
+            }
+          } else {
+            console.log("에러발생");
+            setEmailMessage(
+              "중복 이메일이 있습니다. 다른 이메일을 입력해주세요."
+            );
+            setIsEmail(false);
+          }
+        })
+        .catch(function (error) {
+          console.log(error);
+        });
     }
   }, []);
 
@@ -54,11 +81,38 @@ export default function SignEssentialForm({}) {
     (e) => {
       setNickname(e.target.value);
       if (e.target.value.length < 2 || e.target.value.length > 5) {
-        setNicknameMessage("2글자 이상 5글자 미만으로 입력해주세요.");
+        setNicknameMessage("2글자 이상 5글자 이하로 입력해주세요.");
         setIsNickname(false);
       } else {
-        setNicknameMessage("올바른 닉네임 형식입니다.");
-        setIsNickname(true);
+        axios
+          .get("/api/v1/users/check-nickname-duplication", {
+            params: {
+              nickname: e.target.value,
+            },
+          })
+          .then(function (response) {
+            if (response.data.message.includes("성공")) {
+              console.log(response.data.data.isDuplicated);
+              if (response.data.data.isDuplicated === false) {
+                setNicknameMessage("사용 가능한 닉네임입니다.");
+                setIsNickname(true);
+              } else {
+                setNicknameMessage(
+                  "중복 닉네임이 있습니다. 다른 닉네임을 입력해주세요."
+                );
+                setIsNickname(false);
+              }
+            } else {
+              console.log("에러발생");
+              setNicknameMessage(
+                "중복 닉네임이 있습니다. 다른 닉네임을 입력해주세요."
+              );
+              setIsNickname(false);
+            }
+          })
+          .catch(function (error) {
+            console.log(error);
+          });
       }
     },
     [setNickname]


### PR DESCRIPTION
## 이메일/ 닉네임 중복 검사 기능 추가

### 지라 티켓 번호
MOKA-96

### 구현 내용
회원 가입 시 이메일 / 닉네임 중복 검사 기능

![image](https://user-images.githubusercontent.com/81613151/198172475-9dcb9901-23bf-4770-8f7b-c5d6ad7b45e2.png)
⬆모두 중복 없이 잘 입력했을 때

![image](https://user-images.githubusercontent.com/81613151/198172560-83491134-bab2-489d-959e-7c688ecf2dfa.png)
⬆중복 있을 때

✔중복 있을 때에 가입 버튼 안눌리게 막아두었습니다!

### 리뷰 포인트
오류가 있는지 봐주세요...

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->