### PR TITLE
feat: 마이페이지 생성 카드형 설문 조회 구현 완료

### DIFF
--- a/src/components/surveys/participate/CardQuestionItemDisabled.jsx
+++ b/src/components/surveys/participate/CardQuestionItemDisabled.jsx
@@ -1,0 +1,52 @@
+import { LocalConvenienceStoreOutlined } from "@mui/icons-material";
+import React from "react";
+import styled from "styled-components";
+import {
+  QuestionWrapper,
+  QuestionOption,
+  QuestionText,
+  QuestionContentWrapper,
+} from "../create-card/styled";
+import { surveyForCreated } from "../../../atoms";
+import { useRecoilValue } from "recoil";
+
+const QWrapper = styled.div`
+  width: 50%;
+  padding: 20px 35px 20px 35px;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+`;
+
+export default function CardQuestionItemDisabled({ item, multiquestion }) {
+  const survey = useRecoilValue(surveyForCreated);
+
+  const index = survey.questions.findIndex(
+    (listItem) => listItem.questionId === item.questionId
+  );
+
+  return (
+    <QWrapper>
+      <QuestionText color="#0064ff">Q{index + 1}</QuestionText>
+      <QuestionText color="white">{item.title}</QuestionText>
+      <QuestionContentWrapper>
+        {multiquestion
+          .filter(
+            (multiQuestionItem) =>
+              item.questionId === multiQuestionItem.questionId
+          )
+          .map((multiQuestion) => (
+            <QuestionOption
+              disabled
+              id={multiQuestion.multiQuestionId}
+              key={multiQuestion.multiQuestionId}
+              value={multiQuestion.multiQuestionContent}
+              style={{ pointerEvents: "none" }}
+            >
+              {multiQuestion.multiQuestionContent}
+            </QuestionOption>
+          ))}
+      </QuestionContentWrapper>
+    </QWrapper>
+  );
+}

--- a/src/components/surveys/participate/ShowCardSurvey.jsx
+++ b/src/components/surveys/participate/ShowCardSurvey.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import styled from "styled-components";
+import CardQuestionItem from "./CardQuestionItem";
+import CardQuestionItemDisabled from "./CardQuestionItemDisabled";
+
+const Section = styled.div`
+  height: calc(var(--vh, 1vh) * 75);
+  background-color: #202632;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: -5%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Wrapper = styled.div`
+  width: 100%;
+  min-height: calc(var(--vh, 1vh) * 100);
+  float: right;
+  display: flex;
+  flex-direction: column;
+  background-color: #202632;
+`;
+
+const TitleText = styled.div`
+  margin-top: 7%;
+  font-weight: 900;
+  font-size: xx-large;
+  border: none;
+  color: white;
+  text-align: center;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const SummaryText = styled.div`
+  margin-top: 10px;
+  font-weight: 500;
+  font-size: medium;
+  border: none;
+  color: white;
+  text-align: center;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+export default function ShowCardSurvey({ survey }) {
+  console.log(survey);
+  return (
+    <Wrapper>
+      <TitleText>{survey.title}</TitleText>
+      <SummaryText>{survey.summary}</SummaryText>
+      {survey.questions.map((question, index) => (
+        <Section>
+          <CardQuestionItemDisabled
+            key={question.questionId}
+            item={question}
+            multiquestion={survey.multiQuestions}
+          ></CardQuestionItemDisabled>
+        </Section>
+      ))}
+    </Wrapper>
+  );
+}

--- a/src/components/surveys/participate/ShowSurvey.jsx
+++ b/src/components/surveys/participate/ShowSurvey.jsx
@@ -11,12 +11,22 @@ import { surveyForCreated } from "../../../atoms";
 import { useRecoilState } from "recoil";
 import * as Sentry from "@sentry/react";
 import { getAccessToken, getRefreshToken } from "../../../authentication/auth";
+import ShowCardSurvey from "./ShowCardSurvey";
 
 export default function ShowSurvey({ sharingKey }) {
   const [survey, setSurvey] = useRecoilState(surveyForCreated);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [errorMessage, setErrorMessage] = useState(null);
+
+  function checkingCard() {
+    if (survey.questions[0].type === "MULTIPLE_CHOICE") {
+      if (survey.multiQuestions[0].multiQuestionType === "CARD") {
+        return true;
+      }
+    }
+    return false;
+  }
 
   useEffect(() => {
     axios
@@ -47,33 +57,37 @@ export default function ShowSurvey({ sharingKey }) {
 
   if (error) return <Error errorMessage={errorMessage}></Error>;
   if (loading) return <Loading></Loading>;
-
+  console.log(survey.multiQuestions[0].multiQuestionType);
   return (
     <Container>
       <SNavBar></SNavBar>
-      <Survey>
-        <TitleText>{survey.title}</TitleText>
-        <SummaryText>{survey.summary}</SummaryText>
-        {survey.questions.map((question) =>
-          question.type === "ESSAY" ? (
-            <EssayQuestionItemDisabled
-              key={question.questionId}
-              item={question}
-            ></EssayQuestionItemDisabled>
-          ) : question.type === "OX" ? (
-            <OXQuestionItemDisabled
-              key={question.questionId}
-              item={question}
-            ></OXQuestionItemDisabled>
-          ) : (
-            <MultipleChoiceQuestionItemDisabled
-              key={question.questionId}
-              item={question}
-              multiquestion={survey.multiQuestions}
-            ></MultipleChoiceQuestionItemDisabled>
-          )
-        )}
-      </Survey>
+      {checkingCard() ? (
+        <ShowCardSurvey survey={survey}></ShowCardSurvey>
+      ) : (
+        <Survey>
+          <TitleText>{survey.title}</TitleText>
+          <SummaryText>{survey.summary}</SummaryText>
+          {survey.questions.map((question) =>
+            question.type === "ESSAY" ? (
+              <EssayQuestionItemDisabled
+                key={question.questionId}
+                item={question}
+              ></EssayQuestionItemDisabled>
+            ) : question.type === "OX" ? (
+              <OXQuestionItemDisabled
+                key={question.questionId}
+                item={question}
+              ></OXQuestionItemDisabled>
+            ) : (
+              <MultipleChoiceQuestionItemDisabled
+                key={question.questionId}
+                item={question}
+                multiquestion={survey.multiQuestions}
+              ></MultipleChoiceQuestionItemDisabled>
+            )
+          )}
+        </Survey>
+      )}
     </Container>
   );
 }

--- a/src/pages/surveys/showCardSurvey/index.js
+++ b/src/pages/surveys/showCardSurvey/index.js
@@ -1,0 +1,6 @@
+import React from "react";
+import ShowCardSurvey from "../../../components/surveys/participate/ShowCardSurvey";
+
+export default function ShowCard() {
+  return <ShowCardSurvey></ShowCardSurvey>;
+}


### PR DESCRIPTION
## 마이페이지 생성 카드형 설문 조회 구현 완료 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-115

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
* 마이페이지에서 카드형 설문 조회 완료
* 생성 설문에서 카드/일반형 설문에 따라 다르게 보여줌

### 리뷰 포인트
<!-- 오류 있는지 함께 확인해주세요 -->
* 유형에 따라 설문이 잘 보이는지 확인해주세요!

**카드형 설문**
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/63833392/198691563-6a91ec38-6f08-43e8-938f-eb168c5797a4.png">

**일반형 설문**
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/63833392/198691664-ec19f8e9-0a07-42a2-bbad-39b23d9a6d83.png">


### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ] 코드 리팩토링 