### PR TITLE
feat: 비밀번호 재설정 페이지 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,8 @@ import { useRecoilValue } from "recoil";
 import { userState } from "./authentication/userState";
 import CreateCardSurvey from "./pages/surveys/create/card/index";
 import { useEffect } from "react";
-import { NotFound } from './components/common/NotFound';
+import { NotFound } from "./components/common/NotFound";
+import ResetPassword from "./pages/users/ResetPassword";
 
 const GlobalStyle = createGlobalStyle`
   ${reset}
@@ -51,6 +52,7 @@ function App() {
         ></Route>
         <Route path={routes.signup} element={<SignUp />}></Route>
         <Route path={routes.signin} element={<SignIn />}></Route>
+        <Route path={routes.resetPassword} element={<ResetPassword />}></Route>
         <Route
           path={routes.createSurvey}
           element={
@@ -95,10 +97,7 @@ function App() {
             user !== null ? <CreateCardSurvey /> : <SignIn signInAlert={true} />
           }
         ></Route>
-        <Route
-        path={"*"}
-        element={<NotFound />}
-        ></Route>
+        <Route path={"*"} element={<NotFound />}></Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/users/signIn/AuthMenu.jsx
+++ b/src/components/users/signIn/AuthMenu.jsx
@@ -1,11 +1,32 @@
-import { AuthMenuContainer, SignUpLink } from "./styled";
+import { AuthMenuContainer, SignUpLink, ResetPasswordLink } from "./styled";
+import styled from "styled-components";
+
+const Wrapper = styled.div`
+  margin-top: 25px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+`;
+
+const Distinguish = styled.p`
+  margin-left: 20px;
+  margin-right: 20px;
+  color: gray;
+  font-size: smaller;
+`;
 
 function AuthMenu() {
   return (
-    <AuthMenuContainer>
-      <p>아직 계정이 없으신가요?</p>
-      <SignUpLink to="/signup">회원가입하기</SignUpLink>
-    </AuthMenuContainer>
+    // <AuthMenuContainer>
+    //   <p>아직 계정이 없으신가요?</p>
+    //   <SignUpLink to="/signup">회원가입하기</SignUpLink>
+    // </AuthMenuContainer>
+    <Wrapper>
+      <ResetPasswordLink to="/reset-password">비밀번호 찾기</ResetPasswordLink>
+      <Distinguish>|</Distinguish>
+      <SignUpLink to="/signup">회원가입</SignUpLink>
+    </Wrapper>
   );
 }
 

--- a/src/components/users/signIn/AuthMenu.jsx
+++ b/src/components/users/signIn/AuthMenu.jsx
@@ -1,20 +1,11 @@
-import { AuthMenuContainer, SignUpLink, ResetPasswordLink } from "./styled";
+import {
+  AuthMenuContainer,
+  SignUpLink,
+  ResetPasswordLink,
+  Wrapper,
+  Distinguish,
+} from "./styled";
 import styled from "styled-components";
-
-const Wrapper = styled.div`
-  margin-top: 25px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-`;
-
-const Distinguish = styled.p`
-  margin-left: 20px;
-  margin-right: 20px;
-  color: gray;
-  font-size: smaller;
-`;
 
 function AuthMenu() {
   return (

--- a/src/components/users/signIn/ResetContainer.jsx
+++ b/src/components/users/signIn/ResetContainer.jsx
@@ -1,0 +1,41 @@
+import SocialLoginContainer from "./SocialLoginContainer";
+import AuthMenu from "./AuthMenu";
+import { LoginFormWrapper } from "./styled";
+import styled from "styled-components";
+import ResetFormBox from "./ResetFormBox";
+
+const InfoTitle = styled.h1`
+  font-size: larger;
+  font-weight: 600;
+  color: #202632;
+  margin-bottom: 30px;
+`;
+
+const InfoText = styled.h6`
+  font-size: small;
+  color: #202632;
+  margin-top: 10px;
+  color: gray;
+`;
+
+const CenterWrapper = styled.div`
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  display: flex;
+`;
+
+function ResetContainer() {
+  return (
+    <LoginFormWrapper>
+      <CenterWrapper>
+        <InfoTitle>비밀번호를 잊어버리셨나요?</InfoTitle>
+        <InfoText>가입한 계정 정보를 입력해주세요.</InfoText>
+        <InfoText>계정 이메일로 비밀번호 재설정 링크를 보내드립니다.</InfoText>
+      </CenterWrapper>
+      <ResetFormBox />
+    </LoginFormWrapper>
+  );
+}
+
+export default ResetContainer;

--- a/src/components/users/signIn/ResetContainer.jsx
+++ b/src/components/users/signIn/ResetContainer.jsx
@@ -1,29 +1,8 @@
 import SocialLoginContainer from "./SocialLoginContainer";
 import AuthMenu from "./AuthMenu";
-import { LoginFormWrapper } from "./styled";
+import { LoginFormWrapper, InfoTitle, InfoText, CenterWrapper } from "./styled";
 import styled from "styled-components";
 import ResetFormBox from "./ResetFormBox";
-
-const InfoTitle = styled.h1`
-  font-size: larger;
-  font-weight: 600;
-  color: #202632;
-  margin-bottom: 30px;
-`;
-
-const InfoText = styled.h6`
-  font-size: small;
-  color: #202632;
-  margin-top: 10px;
-  color: gray;
-`;
-
-const CenterWrapper = styled.div`
-  align-items: center;
-  flex-direction: column;
-  justify-content: center;
-  display: flex;
-`;
 
 function ResetContainer() {
   return (

--- a/src/components/users/signIn/ResetFormBox.jsx
+++ b/src/components/users/signIn/ResetFormBox.jsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import TextField from "@mui/material/TextField";
+import { styled } from "@mui/material/styles";
+import { useNavigate } from "react-router-dom";
+import { LocalLoginWrapper, LoginInputContainer, LoginButton } from "./styled";
+import { useRecoilState } from "recoil";
+import { userState } from "../../../authentication/userState";
+import * as Sentry from "@sentry/react";
+import {
+  getAccessToken,
+  getRefreshToken,
+  logout,
+  setTokens,
+  updateAccessToken,
+} from "../../../authentication/auth";
+import CustomTextField from "../../common/CustomTextField";
+import apiClient from "../../../api/client";
+
+function ResetFormBox() {
+  const [inputs, setInputs] = useState({
+    email: "",
+    password: "",
+  });
+
+  const [user, setUser] = useRecoilState(userState);
+  const navigate = useNavigate();
+
+  const handleChange = (event) => {
+    const name = event.target.name;
+    const value = event.target.value;
+    setInputs((values) => ({ ...values, [name]: value }));
+  };
+
+  // TODO: API 주소 변경 필요!
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    apiClient
+      .post("/api/v1/users/login", {
+        email: inputs.email,
+        password: inputs.password,
+      })
+      .then(function (response) {
+        if (response.data.message.includes("성공")) {
+          // 로그인 성공 시 로컬 스토리지에 저장
+          localStorage.clear();
+        } else if (response.data.code === "U001") {
+          alert("이메일 또는 비밀번호가 일치하지 않습니다.");
+        } else {
+          window.alert("로그인 에러 발생");
+        }
+        setTokens(
+          response.data.data.refreshToken,
+          response.data.data.accessToken
+        );
+      })
+      .catch(function (error) {
+        window.alert("이메일 또는 비밀번호가 일치하지 않습니다.");
+      });
+  };
+  return (
+    <LocalLoginWrapper>
+      <form onSubmit={handleSubmit}>
+        <LoginInputContainer>
+          <CustomTextField
+            type="text"
+            name="email"
+            label="이메일"
+            variant="filled"
+            size="small"
+            value={inputs.email || ""}
+            onChange={handleChange}
+          />
+        </LoginInputContainer>
+        <div>
+          <div>
+            <LoginButton type="submit">비밀번호 재설정 메일 보내기</LoginButton>
+          </div>
+        </div>
+      </form>
+    </LocalLoginWrapper>
+  );
+}
+
+export default ResetFormBox;

--- a/src/components/users/signIn/styled.js
+++ b/src/components/users/signIn/styled.js
@@ -91,7 +91,7 @@ const ResetPasswordLink = styled(Link)`
 `;
 
 const SignUpLink = styled(Link)`
-  position: absolute;
+  /* position: absolute; */
   top: 0%;
   right: 0%;
   text-decoration: none;

--- a/src/components/users/signIn/styled.js
+++ b/src/components/users/signIn/styled.js
@@ -131,6 +131,37 @@ const KaKaoLoginImg = styled.img`
 
   object-fit: cover;
 `;
+const InfoTitle = styled.h1`
+  font-size: larger;
+  font-weight: 600;
+  color: #202632;
+  margin-bottom: 30px;
+`;
+const InfoText = styled.h6`
+  font-size: small;
+  color: #202632;
+  margin-top: 10px;
+  color: gray;
+`;
+const CenterWrapper = styled.div`
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  display: flex;
+`;
+const Wrapper = styled.div`
+  margin-top: 25px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+`;
+const Distinguish = styled.p`
+  margin-left: 20px;
+  margin-right: 20px;
+  color: gray;
+  font-size: smaller;
+`;
 
 export {
   LocalLoginWrapper,
@@ -143,4 +174,9 @@ export {
   LoginFormWrapper,
   SocialLoginWrapper,
   KaKaoLoginImg,
+  InfoTitle,
+  InfoText,
+  CenterWrapper,
+  Wrapper,
+  Distinguish,
 };

--- a/src/pages/users/ResetPassword/index.jsx
+++ b/src/pages/users/ResetPassword/index.jsx
@@ -1,0 +1,50 @@
+import { Box, StyledEngineProvider } from "@mui/material";
+import styled from "styled-components";
+import LoginFormContainer from "../../../components/users/signIn/LoginFormContainer";
+import { SignInLogo } from "../../../components/common/Logo";
+import { useEffect } from "react";
+import ResetContainer from "../../../components/users/signIn/ResetContainer";
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background-color: #f5f6fa;
+`;
+
+const RoundedBox = styled(Box)`
+  background-color: white;
+  border-radius: 20px;
+  border: 1px;
+  padding: 40px;
+`;
+
+const LogoContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  justify-content: center;
+  margin-top: 20px;
+  margin-bottom: 50px;
+`;
+
+const Logo = styled.img`
+  height: 144px;
+`;
+
+function ResetPassword() {
+  return (
+    <Container>
+      <StyledEngineProvider injectFirst>
+        <RoundedBox>
+          <LogoContainer>
+            <SignInLogo to="/">MOKAFORM</SignInLogo>
+          </LogoContainer>
+          <ResetContainer />
+        </RoundedBox>
+      </StyledEngineProvider>
+    </Container>
+  );
+}
+
+export default ResetPassword;


### PR DESCRIPTION
## 비밀번호 재설정 페이지 구현

### 지라 티켓 번호
MOKA-136

### 구현 내용
![image](https://user-images.githubusercontent.com/81613151/200121818-bee8a493-0d41-4ca3-af32-bc3355551f3b.png)
🔼로그인 페이지


![image](https://user-images.githubusercontent.com/81613151/200121777-e5e08c3b-e119-46fe-a6f9-f51656b7dfc1.png)
🔼비밀번호 재설정 페이지

- 로그인 페이지 하단에 **비밀번호 찾기** 링크 생성
- 비밀번호 재설정 페이지 생성

### 리뷰 포인트
비밀번호 재설정이 이메일로 오는게 맞겠죠..? 아니라면 수정하겠습니당!

### TODO
API를 연결하여 기능 구현을 할 예정입니다.